### PR TITLE
6 uniform way to style every part of the sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ You can use the BottomSheet component in any SvelteKit project.
     <BottomSheet bind:isOpen={isOpen} settings={{maxHeight: '70%'}}>
       <BottomSheet.Overlay>
          <BottomSheet.Sheet>
+            <BottomSheet.Handle />
             <BottomSheet.Content>
                <h3>Content inside the bottom sheet</h3>
                <p>Here you can put any content you need.</p>
@@ -102,6 +103,7 @@ There is a lot of stuff you can use inside `BottomSheet` which will be explained
 	</BottomSheet.Trigger>
 	<BottomSheet.Overlay>
 		<BottomSheet.Sheet>
+         <BottomSheet.Handle />
 			<BottomSheet.Content>
 				<h3>Bottom Sheet Title</h3>
 				<p>Text</p>
@@ -145,10 +147,12 @@ There is a lot of stuff you can use inside `BottomSheet` which will be explained
    </BottomSheet>
    ```
 
-4. **Overlay & Content:**
+4. **Overlay & Content & Handle:**
    If you want to add a Overlay, you can do that by wrapping the `BottomSheet.Sheet` with `BottomSheet.Overlay`. You can style the overlay using the `style` property.
 
    You can use `BottomSheet.Content` inside `BottomSheet.Sheet` to display content. It's optional, but you are able to style it.
+
+   When you place `BottomSheet.Handle` inside `BottomSheet.Sheet` you will get a style-able handle.
 
 5. **Customizing the Sheet:**  
    The content inside the `BottomSheet.Sheet` component is fully customizable. You can add everything (really everything).

--- a/src/lib/BottomSheet/BottomSheet.svelte
+++ b/src/lib/BottomSheet/BottomSheet.svelte
@@ -6,8 +6,8 @@
 	let {
 		isOpen = $bindable(false),
 		onopen,
-		settings = { maxHeight: '70%', snapPoints: [] },
 		onclose,
+		settings = { maxHeight: '70%', snapPoints: [] },
 		children
 	}: {
 		isOpen?: boolean;

--- a/src/lib/BottomSheet/Handle/Handle.svelte
+++ b/src/lib/BottomSheet/Handle/Handle.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let { ...rest }: HTMLAttributes<HTMLDivElement> = $props();
+</script>
+
+<div {...rest} class="bottom-sheet-handle {rest.class}"></div>
+
+<style>
+	.bottom-sheet-handle {
+		width: 40px;
+		height: 4px;
+		background-color: #e0e0e0;
+		border-radius: 2px;
+		margin: 16px auto;
+	}
+</style>

--- a/src/lib/BottomSheet/Overlay/Overlay.svelte
+++ b/src/lib/BottomSheet/Overlay/Overlay.svelte
@@ -4,8 +4,13 @@
 	import { cubicOut } from 'svelte/easing';
 	import type { HTMLAttributes } from 'svelte/elements';
 	import { fade, slide } from 'svelte/transition';
+	import Handle from '../Handle/Handle.svelte';
 
-	const { isSheetVisible } = getContext<SheetContext>('sheetStateContext');
+	const sheetContext = getContext<SheetContext>('sheetStateContext');
+	if (!sheetContext) {
+		throw new Error('BottomSheet.Overlay must be inside a BottomSheet component');
+	}
+	const { isSheetVisible } = sheetContext;
 
 	let { children, ...rest }: { children?: any } & HTMLAttributes<HTMLDivElement> = $props();
 </script>

--- a/src/lib/BottomSheet/Sheet/Sheet.svelte
+++ b/src/lib/BottomSheet/Sheet/Sheet.svelte
@@ -5,6 +5,8 @@
 	import type { BottomSheetSettings, SheetContext } from '$lib/types.js';
 	import { get } from 'svelte/store';
 	import type { HTMLAttributes } from 'svelte/elements';
+	import Handle from '../Handle/Handle.svelte';
+	import Content from '../Content/Content.svelte';
 
 	const { isSheetVisible, closeSheet, getSettings } = getContext<SheetContext>('sheetStateContext');
 
@@ -179,7 +181,6 @@
 		onmouseup={moveEnd}
 		transition:slide={{ duration: 500, easing: cubicOut }}
 	>
-		<div class="bottom-sheet-handle"></div>
 		<div
 			bind:this={sheetContent}
 			class="bottom-sheet-content"

--- a/src/lib/BottomSheet/Sheet/Sheet.svelte
+++ b/src/lib/BottomSheet/Sheet/Sheet.svelte
@@ -8,14 +8,17 @@
 	import Handle from '../Handle/Handle.svelte';
 	import Content from '../Content/Content.svelte';
 
-	const { isSheetVisible, closeSheet, getSettings } = getContext<SheetContext>('sheetStateContext');
-
 	let {
 		children,
 		...rest
 	}: {
 		children?: any;
 	} & HTMLAttributes<HTMLDivElement> = $props();
+	const sheetContext = getContext<SheetContext>('sheetStateContext');
+	if (!sheetContext) {
+		throw new Error('BottomSheet.Sheet must be inside a BottomSheet component');
+	}
+	const { isSheetVisible, closeSheet, getSettings } = sheetContext;
 
 	let maxHeight = getSettings().maxHeight ?? '70%';
 	let snapPoints: number[] = getSettings().snapPoints ?? [];

--- a/src/lib/BottomSheet/Trigger/Trigger.svelte
+++ b/src/lib/BottomSheet/Trigger/Trigger.svelte
@@ -5,12 +5,17 @@
 
 	let { children, ...rest }: { children?: any } & HTMLAttributes<HTMLDivElement> = $props();
 
-	const { toggleSheet } = getContext<SheetContext>('sheetStateContext');
-	const click = () => {
+	const sheetContext = getContext<SheetContext>('sheetStateContext');
+	if (!sheetContext) {
+		throw new Error('BottomSheet.Overlay must be inside a BottomSheet component');
+	}
+	const { toggleSheet } = sheetContext;
+
+	const handleClick = () => {
 		toggleSheet();
 	};
 </script>
 
-<div {...rest} role="button" tabindex="0" onclick={click}>
+<div {...rest} role="button" tabindex="0" onclick={handleClick}>
 	{@render children?.()}
 </div>

--- a/src/lib/BottomSheet/index.ts
+++ b/src/lib/BottomSheet/index.ts
@@ -1,14 +1,16 @@
 import type { BottomSheetType } from '$lib/types.js';
 import BottomSheetContent from './Content/Content.svelte';
 import Sheet from './Sheet/Sheet.svelte';
-import SheetV2 from './BottomSheet.svelte';
+import BottomSheet from './BottomSheet.svelte';
 import Trigger from './Trigger/Trigger.svelte';
 import Overlay from './Overlay/Overlay.svelte';
+import Handle from './Handle/Handle.svelte';
 
-const TypedBottomSheet = SheetV2 as BottomSheetType;
+const TypedBottomSheet = BottomSheet as BottomSheetType;
 TypedBottomSheet.Content = BottomSheetContent;
 TypedBottomSheet.Sheet = Sheet;
 TypedBottomSheet.Trigger = Trigger;
 TypedBottomSheet.Overlay = Overlay;
+TypedBottomSheet.Handle = Handle;
 
 export default TypedBottomSheet;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,6 +4,7 @@ import type BottomSheet from './BottomSheet/BottomSheet.svelte';
 import type SheetTrigger from './BottomSheet/Trigger/Trigger.svelte';
 import { writable, type Writable } from 'svelte/store';
 import type Overlay from './BottomSheet/Overlay/Overlay.svelte';
+import type Handle from './BottomSheet/Handle/Handle.svelte';
 
 export type BottomSheetSettings = {
 	closePercentage?: number;
@@ -20,6 +21,7 @@ export type BottomSheetType = typeof BottomSheet & {
 	Sheet: typeof Sheet;
 	Trigger: typeof SheetTrigger;
 	Overlay: typeof Overlay;
+	Handle: typeof Handle;
 };
 
 export type SheetContext = {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -72,6 +72,7 @@
 		<BottomSheet bind:isOpen={isBasicSheetOpen}>
 			<BottomSheet.Overlay>
 				<BottomSheet.Sheet style="max-width: 600px; ">
+					<BottomSheet.Handle />
 					<BottomSheet.Content>
 						<h3>Basic Bottom Sheet</h3>
 						<p>
@@ -103,6 +104,7 @@
 			bind:isOpen={isSnapPointsSheetOpen}
 		>
 			<BottomSheet.Sheet style="max-width: 600px; ">
+				<BottomSheet.Handle />
 				<BottomSheet.Content>
 					<h3>Bottom Sheet with Snap Points</h3>
 					<p>
@@ -133,6 +135,7 @@
 		<button onclick={() => (isLongListSheetOpen = true)}>Open Scrollable Sheet</button>
 		<BottomSheet bind:isOpen={isLongListSheetOpen}>
 			<BottomSheet.Sheet style="max-width: 600px; ">
+				<BottomSheet.Handle />
 				<BottomSheet.Content>
 					<h3>Scrollable List of Items</h3>
 					<p>
@@ -167,6 +170,7 @@
 				>Trigger</BottomSheet.Trigger
 			>
 			<BottomSheet.Sheet style="max-width: 600px; ">
+				<BottomSheet.Handle />
 				<BottomSheet.Content>
 					<h3>Bottom Sheet Event Tracking</h3>
 					<p>


### PR DESCRIPTION
Closes #6  
Pull Request for Issue #6 

This Pull-request includes following changes:

- Introduction of `BottomSheet.Handle`, which can be placed in `BottomSheet`. This is a style-able handle for the BottomSheet which is optional.
- Added errors when the context doesn't exist. (Happens when The Sheet Elements are outside of `BottomSheet`)