### PR TITLE
#6 - Fix: On Scrollable Sheets you can now use the Handle to drag the shee…

### DIFF
--- a/src/lib/BottomSheet/BottomSheet.svelte
+++ b/src/lib/BottomSheet/BottomSheet.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { BottomSheetSettings, SheetContext } from '$lib/types.js';
-	import { setContext } from 'svelte';
+	import { setContext, type Snippet } from 'svelte';
 	import { writable } from 'svelte/store';
 
 	let {
@@ -15,7 +15,7 @@
 	}: {
 		isOpen?: boolean;
 		settings?: BottomSheetSettings;
-		children: any;
+		children: Snippet<[]>;
 		onopen?: () => void;
 		onclose?: () => void;
 		onsheetdrag?: () => void;

--- a/src/lib/BottomSheet/Content/Content.svelte
+++ b/src/lib/BottomSheet/Content/Content.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
 	import type { HTMLAttributes } from 'svelte/elements';
 
-	let { children, ...rest }: { children?: any } & HTMLAttributes<HTMLDivElement> = $props();
+	let {
+		children,
+		...rest
+	}: { children?: Snippet<[]> | undefined } & HTMLAttributes<HTMLDivElement> = $props();
 </script>
 
 <div class="bottomSheetContent {rest.class}" {...rest}>

--- a/src/lib/BottomSheet/Handle/Handle.svelte
+++ b/src/lib/BottomSheet/Handle/Handle.svelte
@@ -4,7 +4,9 @@
 	let { ...rest }: HTMLAttributes<HTMLDivElement> = $props();
 </script>
 
-<div {...rest} class="bottom-sheet-handle {rest.class}"></div>
+<div class="handle-container">
+	<div {...rest} class="bottom-sheet-handle {rest.class}"></div>
+</div>
 
 <style>
 	.bottom-sheet-handle {
@@ -13,5 +15,12 @@
 		background-color: #e0e0e0;
 		border-radius: 2px;
 		margin: 16px auto;
+	}
+	.handle-container {
+		height: 40px;
+		width: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
 	}
 </style>

--- a/src/lib/BottomSheet/Overlay/Overlay.svelte
+++ b/src/lib/BottomSheet/Overlay/Overlay.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { SheetContext } from '$lib/types.js';
-	import { getContext } from 'svelte';
+	import { getContext, type Snippet } from 'svelte';
 	import { cubicOut } from 'svelte/easing';
 	import type { HTMLAttributes } from 'svelte/elements';
 	import { fade, slide } from 'svelte/transition';
@@ -12,7 +12,10 @@
 	}
 	const { isSheetVisible } = sheetContext;
 
-	let { children, ...rest }: { children?: any } & HTMLAttributes<HTMLDivElement> = $props();
+	let {
+		children,
+		...rest
+	}: { children?: Snippet<[]> | undefined } & HTMLAttributes<HTMLDivElement> = $props();
 </script>
 
 {#if $isSheetVisible}

--- a/src/lib/BottomSheet/Trigger/Trigger.svelte
+++ b/src/lib/BottomSheet/Trigger/Trigger.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
 	import type { SheetContext } from '$lib/types.js';
-	import { getContext } from 'svelte';
+	import { getContext, type Snippet } from 'svelte';
 	import type { HTMLAttributes } from 'svelte/elements';
 
-	let { children, ...rest }: { children?: any } & HTMLAttributes<HTMLDivElement> = $props();
+	let {
+		children,
+		...rest
+	}: { children?: Snippet<[]> | undefined } & HTMLAttributes<HTMLDivElement> = $props();
 
 	const sheetContext = getContext<SheetContext>('sheetStateContext');
 	if (!sheetContext) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -71,7 +71,7 @@
 		<button onclick={() => (isBasicSheetOpen = true)}>Open Bottom Sheet</button>
 		<BottomSheet bind:isOpen={isBasicSheetOpen}>
 			<BottomSheet.Overlay>
-				<BottomSheet.Sheet style="max-width: 600px; ">
+				<BottomSheet.Sheet style="max-width: 600px;">
 					<BottomSheet.Handle />
 					<BottomSheet.Content>
 						<h3>Basic Bottom Sheet</h3>
@@ -134,7 +134,7 @@
 		</p>
 		<button onclick={() => (isLongListSheetOpen = true)}>Open Scrollable Sheet</button>
 		<BottomSheet bind:isOpen={isLongListSheetOpen}>
-			<BottomSheet.Sheet style="max-width: 600px; ">
+			<BottomSheet.Sheet style="max-width: 600px;">
 				<BottomSheet.Handle />
 				<BottomSheet.Content>
 					<h3>Scrollable List of Items</h3>


### PR DESCRIPTION
Close #12 
Fixed the bug where you weren't able to drag down the Scrollable Bottom Sheet via the Handle when the content wasn't scrolled to the top

