### PR TITLE
Snappoints Enhancements:

### DIFF
--- a/src/lib/BottomSheet/Sheet/Sheet.svelte
+++ b/src/lib/BottomSheet/Sheet/Sheet.svelte
@@ -75,7 +75,6 @@
 
 	$effect(() => {
 		if (sheetContext.isSheetOpen) {
-			console.log(previousActiveElement);
 			previousActiveElement = document.activeElement as HTMLElement;
 			document.body.style.overflowY = 'hidden';
 			document.addEventListener('touchmove', preventPullToRefresh, { passive: false });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,6 +9,7 @@ export type BottomSheetSettings = {
 	closePercentage?: number;
 	maxHeight?: string;
 	snapPoints?: number[];
+	startingSnapPoint?: number;
 };
 
 export type BottomSheetType = typeof BottomSheet & {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import BottomSheet from '$lib/BottomSheet/index.js';
-	import Sheet from '$lib/BottomSheet/Sheet/Sheet.svelte';
+	import BottomSheet2 from '$lib/BottomSheet/BottomSheet.svelte';
 	import { tick } from 'svelte';
 	import { fly } from 'svelte/transition';
 
@@ -10,6 +10,13 @@
 	let eventLog = $state<string[]>([]);
 	let isLongListSheetOpen = $state(false);
 
+	let snapPointsSheet: BottomSheet2;
+
+	$effect(() => {
+		if (isSnapPointsSheetOpen) {
+			//snapPointsSheet.setSnapPoint(25);
+		}
+	});
 	const logEvent = async (event: string) => {
 		await tick();
 		eventLog = [...eventLog, `${new Date().toLocaleTimeString()}: ${event}`];
@@ -100,8 +107,10 @@
 		</p>
 		<button onclick={() => (isSnapPointsSheetOpen = true)}>Open Snap Points Sheet</button>
 		<BottomSheet
-			settings={{ maxHeight: '90%', snapPoints: [25, 50, 75] }}
+			bind:this={snapPointsSheet}
+			settings={{ maxHeight: '90%', snapPoints: [25, 50, 75], startingSnapPoint: 50 }}
 			bind:isSheetOpen={isSnapPointsSheetOpen}
+			onsnap={(point) => console.log(`Sheet snapped to ${point}%`)}
 		>
 			<BottomSheet.Sheet style="max-width: 600px; ">
 				<BottomSheet.Handle />


### PR DESCRIPTION
Close #9 
Completed all Tasks related to the issue:
- onsnap-Event - when snapping it provides the snap point which it snapped to
- you can now set a starting snap-point, where the sheet will start, whenever opened
- you can now set the snap-point from outside of the component