### PR TITLE
[Improvement] Make every part of the handle customize-able and allow custom handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,52 @@ This is the functional Bottom Sheet component, which will be shown / hidden when
 
 The handle is more than just a visual element—it provides functional support for user interactions. When dragging the handle, users can always pull down the Bottom Sheet, even if it’s not fully scrolled to the top.
 
-Additionally, it is fully customizable and includes accessibility features, such as opening, closing, and snapping to snap points using arrow keys.
+#### Customizing the Handle
+
+The `BottomSheet.Handle` is fully customizable. You can either use the default grip or provide your own content inside the handle.
+
+- **Default behavior**: If no children are passed to `BottomSheet.Handle`, it renders a default `BottomSheet.Grip`, which is a simple, accessible visual indicator.
+- **Custom styles**: You can customize the appearance of the grip by passing it explicitly as a child and applying your own styles.
+- **Custom content**: Alternatively, you can provide any custom content—text, icons, or components—as children of the handle.
+
+#### Examples
+
+Customize the grip color:
+
+````svelte
+<BottomSheet>
+	<BottomSheet.Overlay>
+		<BottomSheet.Sheet>
+			<BottomSheet.Handle style="background-color: green">
+				<BottomSheet.Grip style="background-color: red" />
+			</BottomSheet.Handle>
+		</BottomSheet.Sheet>
+	</BottomSheet.Overlay>
+</BottomSheet>
+
+Use the default handle with no custom styles: ```svelte
+<BottomSheet>
+	<BottomSheet.Overlay>
+		<BottomSheet.Sheet>
+			<BottomSheet.Handle />
+		</BottomSheet.Sheet>
+	</BottomSheet.Overlay>
+</BottomSheet>
+````
+
+Add custom content inside the handle (e.g., text or icons):
+
+```svelte
+<BottomSheet>
+	<BottomSheet.Overlay>
+		<BottomSheet.Sheet>
+			<BottomSheet.Handle>
+				<p style="margin: 0; font-weight: bold;">Drag me</p>
+			</BottomSheet.Handle>
+		</BottomSheet.Sheet>
+	</BottomSheet.Overlay>
+</BottomSheet>
+```
 
 #### Properties
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The `BottomSheet.Handle` is fully customizable. You can either use the default g
 
 Customize the grip color:
 
-````svelte
+```svelte
 <BottomSheet>
 	<BottomSheet.Overlay>
 		<BottomSheet.Sheet>
@@ -159,8 +159,11 @@ Customize the grip color:
 		</BottomSheet.Sheet>
 	</BottomSheet.Overlay>
 </BottomSheet>
+```
 
-Use the default handle with no custom styles: ```svelte
+Use the default handle with no custom styles:
+
+```svelte
 <BottomSheet>
 	<BottomSheet.Overlay>
 		<BottomSheet.Sheet>
@@ -168,7 +171,7 @@ Use the default handle with no custom styles: ```svelte
 		</BottomSheet.Sheet>
 	</BottomSheet.Overlay>
 </BottomSheet>
-````
+```
 
 Add custom content inside the handle (e.g., text or icons):
 
@@ -313,3 +316,7 @@ Contributions are welcome! If you have any ideas, suggestions, or bug reports, p
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](https://github.com/AuxiDev/svelte-bottom-sheet/blob/master/LICENSE.txt) file for more details.
+
+```
+
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-bottom-sheet",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"license": "MIT",
 	"repository": "https://github.com/AuxiDev/svelte-bottom-sheet",
 	"homepage": "https://bottomsheet.auxi.studio/",

--- a/src/lib/BottomSheet/Grip/Grip.svelte
+++ b/src/lib/BottomSheet/Grip/Grip.svelte
@@ -12,6 +12,6 @@
 		height: 4px;
 		background-color: #e0e0e0;
 		border-radius: 2px;
-		margin: 16px;
+		margin: 8px;
 	}
 </style>

--- a/src/lib/BottomSheet/Grip/Grip.svelte
+++ b/src/lib/BottomSheet/Grip/Grip.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let { ...rest }: HTMLAttributes<HTMLDivElement> = $props();
+</script>
+
+<div {...rest} class="bottom-sheet-grip {rest.class}" aria-hidden="true"></div>
+
+<style>
+	.bottom-sheet-grip {
+		width: 40px;
+		height: 4px;
+		background-color: #e0e0e0;
+		border-radius: 2px;
+		margin: 16px auto;
+	}
+</style>

--- a/src/lib/BottomSheet/Grip/Grip.svelte
+++ b/src/lib/BottomSheet/Grip/Grip.svelte
@@ -12,6 +12,6 @@
 		height: 4px;
 		background-color: #e0e0e0;
 		border-radius: 2px;
-		margin: 16px auto;
+		margin: 16px;
 	}
 </style>

--- a/src/lib/BottomSheet/Handle/Handle.svelte
+++ b/src/lib/BottomSheet/Handle/Handle.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import type { SheetContext } from '$lib/types.js';
 	import { measurementToPx } from '$lib/utils.js';
-	import { getContext } from 'svelte';
+	import { getContext, type Snippet } from 'svelte';
 	import type { HTMLAttributes } from 'svelte/elements';
+	import Grip from '../Grip/Grip.svelte';
 
 	const sheetContext = getContext<SheetContext>('sheetContext');
 
@@ -10,7 +11,7 @@
 		throw new Error('BottomSheet.Overlay must be inside a BottomSheet component');
 	}
 
-	let { ...rest }: HTMLAttributes<HTMLDivElement> = $props();
+	let { children, ...rest }: { children?: Snippet<[]> } & HTMLAttributes<HTMLDivElement> = $props();
 
 	const handleKeyDown = (event: KeyboardEvent) => {
 		if (sheetContext.settings.disableDragging) return;
@@ -64,8 +65,13 @@
 	aria-valuemax="100"
 	aria-valuenow={Math.round((1 - sheetContext.sheetHeight / window.innerHeight) * 100)}
 	onkeydown={handleKeyDown}
+	{...rest}
 >
-	<div {...rest} class="bottom-sheet-handle {rest.class}" aria-hidden="true"></div>
+	{#if children}
+		{@render children?.()}
+	{:else}
+		<Grip />
+	{/if}
 </div>
 
 <style>
@@ -93,8 +99,8 @@
 		height: 100%;
 	}
 
-	.position-left .bottom-sheet-handle,
-	.position-right .bottom-sheet-handle {
+	.position-left,
+	.position-right {
 		transform: rotate(90deg);
 	}
 

--- a/src/lib/BottomSheet/Handle/Handle.svelte
+++ b/src/lib/BottomSheet/Handle/Handle.svelte
@@ -75,19 +75,12 @@
 </div>
 
 <style>
-	.bottom-sheet-handle {
-		width: 40px;
-		height: 4px;
-		background-color: #e0e0e0;
-		border-radius: 2px;
-		margin: 16px auto;
-	}
 	.handle-container {
 		position: sticky;
-		height: 40px;
 		width: 100%;
 		display: flex;
 		align-items: center;
+		flex-direction: column;
 		justify-content: center;
 		background-color: white;
 		z-index: 51;
@@ -95,13 +88,13 @@
 
 	.position-left,
 	.position-right {
-		width: 40px;
-		height: 100%;
+		width: min-content;
+		transform: rotate(90deg);
 	}
 
-	.position-left,
 	.position-right {
-		transform: rotate(90deg);
+		flex-direction: column-reverse;
+		left: 0;
 	}
 
 	.position-bottom {
@@ -114,10 +107,6 @@
 
 	.position-left {
 		right: 0;
-	}
-
-	.position-right {
-		left: 0;
 	}
 
 	.handle-container:focus-visible {

--- a/src/lib/BottomSheet/index.ts
+++ b/src/lib/BottomSheet/index.ts
@@ -5,6 +5,7 @@ import BottomSheet from './BottomSheet.svelte';
 import Trigger from './Trigger/Trigger.svelte';
 import Overlay from './Overlay/Overlay.svelte';
 import Handle from './Handle/Handle.svelte';
+import Grip from './Grip/Grip.svelte';
 
 const TypedBottomSheet = BottomSheet as BottomSheetType;
 TypedBottomSheet.Content = BottomSheetContent;
@@ -12,5 +13,6 @@ TypedBottomSheet.Sheet = Sheet;
 TypedBottomSheet.Trigger = Trigger;
 TypedBottomSheet.Overlay = Overlay;
 TypedBottomSheet.Handle = Handle;
+TypedBottomSheet.Grip = Grip;
 
 export default TypedBottomSheet;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -6,3 +6,4 @@ export type TypeOfContent = typeof import('./BottomSheet/Content/Content.svelte'
 export type TypeOfHandle = typeof import('./BottomSheet/Handle/Handle.svelte').default;
 export type TypeOfOverlay = typeof import('./BottomSheet/Overlay/Overlay.svelte').default;
 export type TypeOfTrigger = typeof import('./BottomSheet/Trigger/Trigger.svelte').default;
+export type TypeOfGrip = typeof import('./BottomSheet/Grip/Grip.svelte').default;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,6 +4,7 @@ import type BottomSheet from './BottomSheet/BottomSheet.svelte';
 import type SheetTrigger from './BottomSheet/Trigger/Trigger.svelte';
 import type Overlay from './BottomSheet/Overlay/Overlay.svelte';
 import type Handle from './BottomSheet/Handle/Handle.svelte';
+import type Grip from './BottomSheet/Grip/Grip.svelte';
 
 export type sheetPosition = 'bottom' | 'top' | 'left' | 'right';
 
@@ -24,6 +25,7 @@ export type BottomSheetType = typeof BottomSheet & {
 	Trigger: typeof SheetTrigger;
 	Overlay: typeof Overlay;
 	Handle: typeof Handle;
+	Grip: typeof Grip;
 };
 
 export type SheetIdentificationContext = {


### PR DESCRIPTION
Closes #26 
Now `BottomSheet.Handle` allows children. This means you can provide your own handle style with e.g, text. If you want to style the default grip, provide it as children by passing `BottomSheet.Grip`. 

**Documentation excerpt:**

#### Customizing the Handle

The `BottomSheet.Handle` is fully customizable. You can either use the default grip or provide your own content inside the handle.

- **Default behavior**: If no children are passed to `BottomSheet.Handle`, it renders a default `BottomSheet.Grip`, which is a simple, accessible visual indicator.
- **Custom styles**: You can customize the appearance of the grip by passing it explicitly as a child and applying your own styles.
- **Custom content**: Alternatively, you can provide any custom content—text, icons, or components—as children of the handle.

#### Examples

Customize the grip color:

````svelte
<BottomSheet>
	<BottomSheet.Overlay>
		<BottomSheet.Sheet>
			<BottomSheet.Handle style="background-color: green">
				<BottomSheet.Grip style="background-color: red" />
			</BottomSheet.Handle>
		</BottomSheet.Sheet>
	</BottomSheet.Overlay>
</BottomSheet>

Use the default handle with no custom styles: ```svelte
<BottomSheet>
	<BottomSheet.Overlay>
		<BottomSheet.Sheet>
			<BottomSheet.Handle />
		</BottomSheet.Sheet>
	</BottomSheet.Overlay>
</BottomSheet>
````

Add custom content inside the handle (e.g., text or icons):

```svelte
<BottomSheet>
	<BottomSheet.Overlay>
		<BottomSheet.Sheet>
			<BottomSheet.Handle>
				<p style="margin: 0; font-weight: bold;">Drag me</p>
			</BottomSheet.Handle>
		</BottomSheet.Sheet>
	</BottomSheet.Overlay>
</BottomSheet>
```
