### PR TITLE
[FIX] Sheet height not being adjusted on resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,14 +233,14 @@ This is the component where your Bottom Sheet content goes into.
 
 ### ContentAlignmentType [EXPERIMENTAL] (Added with 2.2)
 
-This type was added with 2.2, to allow more complex content alignment for `left` and `right` positioned sheets. The setting affects the `BottomSheet.Content` component and might involve calculations.
+This type was added with 2.2, to allow more complex content alignment for `left` and `right` positioned sheets. These alignments affect the `BottomSheet.Content` component and might involve calculations.
 
 More options will be added if the feature is doing good.
 
-| Name        | Description                                                                                                                                                                                                     |
-| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `flex`      | The content shrinks and grows like a normal flex. No calculations are involved. You can adjust styling and behaviours like you want. This is the default behaviour.                                             |
-| `start-fit` | Calculates the best fit for the content upon the sheets opening. This means, it won't adjust by dragging or snapping to a snap point and stay in it's width. (You may use even padding and margin on the sides) |
+| Name        | Description                                                                                                                                                                                                                                                                |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `flex`      | The content shrinks and grows like a normal flex. No calculations are involved. You can adjust styling and behaviours like you want.                                                                                                                                       |
+| `start-fit` | Calculates the best fit for the content upon the sheet opening only. This means the width is set once based on the content size at mount and won't adjust dynamically when dragging or snapping to other snap points. (You might use even padding and margin on the sides) |
 
 ### Notes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-bottom-sheet",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"license": "MIT",
 	"repository": "https://github.com/AuxiDev/svelte-bottom-sheet",
 	"homepage": "https://bottomsheet.auxi.studio/",

--- a/src/lib/BottomSheet/BottomSheet.svelte
+++ b/src/lib/BottomSheet/BottomSheet.svelte
@@ -11,7 +11,8 @@ to has "height" in it's name.
 		type SheetIdentificationContext
 	} from '$lib/types.js';
 	import { getScrollableElement, measurementToPx } from '$lib/utils.js';
-	import { onMount, setContext, type Snippet } from 'svelte';
+	import { setContext, type Snippet } from 'svelte';
+	import { innerHeight, innerWidth } from 'svelte/reactivity/window';
 
 	let {
 		isSheetOpen = $bindable(false),
@@ -60,14 +61,10 @@ to has "height" in it's name.
 	if (!propSettings.snapPoints?.includes(1)) {
 		propSettings.snapPoints?.push(1);
 	}
+
 	const settings: Required<BottomSheetSettings> = $derived({ ...defaultsettings, ...propSettings });
 
 	let eventController = new AbortController();
-
-	onMount(() => {
-		currentWindowWidth = window.innerWidth;
-		currentWindowHeight = window.innerHeight;
-	});
 
 	$effect(() => {
 		if (isSheetOpen) {
@@ -102,6 +99,7 @@ to has "height" in it's name.
 			document.addEventListener('mousemove', mouseMoveEvent);
 			document.addEventListener('touchmove', preventPullToRefresh, { passive: false });
 			document.addEventListener('keydown', handleKeyDown);
+			resizeObserver.observe(document.documentElement);
 		} else {
 			onclose?.();
 			setSnapPoint(settings.startingSnapPoint, false);
@@ -109,13 +107,10 @@ to has "height" in it's name.
 			document.removeEventListener('touchmove', preventPullToRefresh);
 			document.removeEventListener('keydown', handleKeyDown);
 			document.removeEventListener('mousemove', mouseMoveEvent);
+			resizeObserver.disconnect();
 			eventController.abort();
 		}
 	});
-
-	// Needed for the maxHeightPx derived so it can
-	let currentWindowWidth = $state(0);
-	let currentWindowHeight = $state(0);
 
 	// States & Vars needed for sheet-positon calculation.
 	let sheetHeight = $state(0);
@@ -125,9 +120,8 @@ to has "height" in it's name.
 		if (maxHeight > 1) {
 			return maxHeight;
 		}
-
 		const isSidePosition = position === 'left' || position === 'right';
-		const dimension = isSidePosition ? currentWindowWidth : currentWindowHeight;
+		const dimension = isSidePosition ? (innerWidth.current ?? 0) : (innerHeight.current ?? 0);
 
 		return dimension * maxHeight;
 	});
@@ -139,6 +133,11 @@ to has "height" in it's name.
 	let startHeight: number;
 	let noScrolledTop: number = 0;
 	let startX: number = 0;
+	// svelte-ignore state_referenced_locally
+	let currentSnappoint = settings.startingSnapPoint;
+	const resizeObserver = new ResizeObserver((entries) => {
+		adjustSnappointAfterResize();
+	});
 
 	// A11Y related IDs
 	const sheetId = `bottom-sheet-${Math.random().toString(36).substr(2, 9)}`;
@@ -158,9 +157,19 @@ to has "height" in it's name.
 			if (throwEvent) {
 				onsnap?.(point);
 			}
+			currentSnappoint = point;
 			return true;
 		}
 		return false;
+	};
+
+	/*
+		If a resize happens on a snappoint Bottom Sheet, adjust the point
+	*/
+	const adjustSnappointAfterResize = () => {
+		if (settings.snapPoints.length > 1) {
+			setSnapPoint(currentSnappoint, false);
+		}
 	};
 
 	/*
@@ -411,6 +420,7 @@ to has "height" in it's name.
 						: prev
 			);
 			onsnap?.(closest.original);
+			currentSnappoint = closest.original;
 			sheetHeight = closest.converted;
 		}
 

--- a/src/lib/BottomSheet/BottomSheet.svelte
+++ b/src/lib/BottomSheet/BottomSheet.svelte
@@ -70,6 +70,9 @@ to has "height" in it's name.
 		if (isSheetOpen) {
 			onopen?.();
 			eventController = new AbortController();
+			resizeObserver = new ResizeObserver(() => {
+				adjustSnappointAfterResize();
+			});
 
 			document.addEventListener(
 				'wheel',
@@ -107,7 +110,7 @@ to has "height" in it's name.
 			document.removeEventListener('touchmove', preventPullToRefresh);
 			document.removeEventListener('keydown', handleKeyDown);
 			document.removeEventListener('mousemove', mouseMoveEvent);
-			resizeObserver.disconnect();
+			if (resizeObserver != null) resizeObserver.disconnect();
 			eventController.abort();
 		}
 	});
@@ -135,9 +138,7 @@ to has "height" in it's name.
 	let startX: number = 0;
 	// svelte-ignore state_referenced_locally
 	let currentSnappoint = settings.startingSnapPoint;
-	const resizeObserver = new ResizeObserver((entries) => {
-		adjustSnappointAfterResize();
-	});
+	let resizeObserver: ResizeObserver;
 
 	// A11Y related IDs
 	const sheetId = `bottom-sheet-${Math.random().toString(36).substr(2, 9)}`;


### PR DESCRIPTION
Close #33 
- The sheet height now adjusts correctly on window resize.
- If a snap point sheet was active before the resize, it will now retain the same snap point value