### PR TITLE
[HOTFIX] Clean up event listeners on component destruction to prevent cross-page effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-bottom-sheet",
-	"version": "2.2.2",
+	"version": "2.2.3",
 	"license": "MIT",
 	"repository": "https://github.com/AuxiDev/svelte-bottom-sheet",
 	"homepage": "https://bottomsheet.auxi.studio/",


### PR DESCRIPTION
Close #37 
This PR fixes an issue where event listeners were not being properly removed when a component was destroyed. => listeners persisted across page navigations and could trigger unintended behavior on other pages

Also the `effect`-statement was transformed to be cleaner.